### PR TITLE
Initialize Track Generator plugin

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -1,0 +1,10 @@
+/* Track Generator basic styles */
+.tg-container {
+    padding: 1em;
+    border: 1px solid #ccc;
+    max-width: 400px;
+}
+.tg-container label {
+    display: block;
+    margin: 0.5em 0 0.2em;
+}

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -1,0 +1,50 @@
+(function($) {
+    function randomInt(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    window.tg = {
+        generateBPM: function(min, max) {
+            return randomInt(min, max);
+        },
+        generateKey: function(modes) {
+            var keys = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'];
+            var key = keys[randomInt(0, keys.length - 1)];
+            var mode = modes[randomInt(0, modes.length - 1)];
+            return key + ' ' + mode;
+        },
+        generateProgression: function(type, length) {
+            var tried = [
+                '1 - 4 - 5',
+                '6 - 4 - 1 - 5',
+                '2 - 5 - 1'
+            ];
+            if(type === 'tried') {
+                return tried[randomInt(0, tried.length - 1)];
+            }
+            var prog = [];
+            for(var i=0; i<length; i++) {
+                prog.push(randomInt(1,7));
+            }
+            return prog.join(' - ');
+        }
+    };
+
+    $(document).on('click', '#tg-generate', function() {
+        var bpmMin = parseInt($('#tg-bpm-min').val(), 10);
+        var bpmMax = parseInt($('#tg-bpm-max').val(), 10);
+        var modes = [];
+        $('input[name="tg-modes[]"]:checked').each(function(){
+            modes.push($(this).val());
+        });
+        var progType = $('input[name="tg-prog-type"]:checked').val();
+        var progLength = parseInt($('#tg-prog-length').val(), 10) || 4;
+
+        var result = '';
+        result += '<p><strong>BPM:</strong> ' + tg.generateBPM(bpmMin, bpmMax) + '</p>';
+        result += '<p><strong>Key:</strong> ' + tg.generateKey(modes) + '</p>';
+        result += '<p><strong>Progression:</strong> ' + tg.generateProgression(progType, progLength) + '</p>';
+
+        $('#tg-output').html(result);
+    });
+})(jQuery);

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -1,0 +1,10 @@
+=== Track Generator ===
+Contributors: randellmiller
+Tags: music, bpm, chord progression, key
+Requires at least: 5.0
+Tested up to: 6.2
+Stable tag: 0.1.0
+License: MIT
+License URI: https://opensource.org/licenses/MIT
+
+A simple tool for generating random track ideas.

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -1,0 +1,26 @@
+<div class="tg-container">
+    <label for="tg-bpm-min">BPM Min</label>
+    <input id="tg-bpm-min" type="number" value="60">
+
+    <label for="tg-bpm-max">BPM Max</label>
+    <input id="tg-bpm-max" type="number" value="160">
+
+    <fieldset>
+        <legend>Modes</legend>
+        <label><input type="checkbox" name="tg-modes[]" value="Major" checked> Major</label>
+        <label><input type="checkbox" name="tg-modes[]" value="Natural Minor" checked> Natural Minor</label>
+    </fieldset>
+
+    <fieldset>
+        <legend>Progression Type</legend>
+        <label><input type="radio" name="tg-prog-type" value="tried" checked> Tried and True</label>
+        <label><input type="radio" name="tg-prog-type" value="random"> True Random</label>
+    </fieldset>
+
+    <label for="tg-prog-length">Progression Length (for True Random)</label>
+    <input id="tg-prog-length" type="number" value="4">
+
+    <button id="tg-generate">Generate</button>
+
+    <div id="tg-output"></div>
+</div>

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name:       Track Generator
+ * Description:       Generates random BPM, key, mode, and chord progressions.
+ * Version:           0.1.0
+ * Author:            Randell Miller of Infinite Possibility Media
+ * Plugin URI:        https://infinitepossibility.media
+ * Author URI:        https://infinitepossibility.media
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+function tg_enqueue_assets() {
+    wp_enqueue_style(
+        'track-generator-style',
+        plugin_dir_url(__FILE__) . 'css/style.css'
+    );
+    wp_enqueue_script(
+        'track-generator-js',
+        plugin_dir_url(__FILE__) . 'js/generator.js',
+        array('jquery'),
+        null,
+        true
+    );
+}
+add_action('wp_enqueue_scripts', 'tg_enqueue_assets');
+
+function tg_render_generator() {
+    ob_start();
+    include plugin_dir_path(__FILE__) . 'templates/generator-ui.php';
+    return ob_get_clean();
+}
+add_shortcode('track_generator', 'tg_render_generator');
+?>


### PR DESCRIPTION
## Summary
- scaffold `track-generator` plugin directory
- add plugin file with headers and shortcode/asset setup
- include basic JS logic, CSS, and HTML template
- create minimal `readme.txt` for WordPress metadata

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6840a8da9ac8832a9a2f280d0844b6e7