### PR TITLE
Add full mode selection options

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,7 +10,7 @@ This lightweight plugin adds a track idea generator to any WordPress site. It pr
    - Users select a minimum and maximum BPM (default 60–160).
    - The app outputs a random BPM in that range.
 2. **Key + Mode Selector**
-   - Checkboxes allow the user to enable modes (Major or Natural Minor).
+   - Checkboxes allow the user to enable any of the seven modes (Ionian/Major, Dorian, Phrygian, Lydian, Mixolydian, Aeolian/Natural Minor, Locrian).
    - A key from A–G# is randomly chosen along with one of the selected modes.
 3. **Chord Progression Generator**
    - *Tried and True*: chooses from a curated list of common progressions such as `1 - 4 - 5`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A WordPress plugin that generates random ideas for new music tracks. It provides
 ## Features
 
 - Random BPM within a configurable range
-- Key and mode selector (Major or Natural Minor)
+- Key and mode selector supporting all seven modes (Ionian, Dorian, Phrygian, Lydian, Mixolydian, Aeolian, Locrian)
 - Two chord progression modes: "Tried and True" or a fully random sequence
 
 ## Installation

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -9,6 +9,11 @@
         <legend>Modes</legend>
         <label><input type="checkbox" name="tg-modes[]" value="Major" checked> Major</label>
         <label><input type="checkbox" name="tg-modes[]" value="Natural Minor" checked> Natural Minor</label>
+        <label><input type="checkbox" name="tg-modes[]" value="Dorian"> Dorian</label>
+        <label><input type="checkbox" name="tg-modes[]" value="Phrygian"> Phrygian</label>
+        <label><input type="checkbox" name="tg-modes[]" value="Lydian"> Lydian</label>
+        <label><input type="checkbox" name="tg-modes[]" value="Mixolydian"> Mixolydian</label>
+        <label><input type="checkbox" name="tg-modes[]" value="Locrian"> Locrian</label>
     </fieldset>
 
     <fieldset>


### PR DESCRIPTION
## Summary
- support all seven modes in the generator UI
- document available modes in README and DESIGN docs

## Testing
- `npm test` *(fails: package.json missing)*
- `php -l track-generator/templates/generator-ui.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68428147eeac832a92ab198b2d3b0799