### PR TITLE
Add local storage for option persistence

### DIFF
--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -30,6 +30,35 @@
         }
     };
 
+    $(function() {
+        if (!window.localStorage) { return; }
+        var stored = localStorage.getItem('tg-options');
+        if (!stored) { return; }
+        try {
+            var opts = JSON.parse(stored);
+            if (opts.bpmMin !== undefined) {
+                $('#tg-bpm-min').val(opts.bpmMin);
+            }
+            if (opts.bpmMax !== undefined) {
+                $('#tg-bpm-max').val(opts.bpmMax);
+            }
+            if (Array.isArray(opts.modes)) {
+                $('input[name="tg-modes[]"]').prop('checked', false).each(function(){
+                    if (opts.modes.indexOf($(this).val()) !== -1) {
+                        $(this).prop('checked', true);
+                    }
+                });
+            }
+            if (opts.progType) {
+                $('input[name="tg-prog-type"][value="' + opts.progType + '"]')
+                    .prop('checked', true);
+            }
+            if (opts.progLength !== undefined) {
+                $('#tg-prog-length').val(opts.progLength);
+            }
+        } catch(e) {}
+    });
+
     $(document).on('click', '#tg-generate', function() {
         var bpmMin = parseInt($('#tg-bpm-min').val(), 10);
         var bpmMax = parseInt($('#tg-bpm-max').val(), 10);
@@ -39,6 +68,17 @@
         });
         var progType = $('input[name="tg-prog-type"]:checked').val();
         var progLength = parseInt($('#tg-prog-length').val(), 10) || 4;
+
+        if (window.localStorage) {
+            var opts = {
+                bpmMin: bpmMin,
+                bpmMax: bpmMax,
+                modes: modes,
+                progType: progType,
+                progLength: progLength
+            };
+            localStorage.setItem('tg-options', JSON.stringify(opts));
+        }
 
         var result = '';
         result += '<p><strong>BPM:</strong> ' + tg.generateBPM(bpmMin, bpmMax) + '</p>';

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.1.0
+ * Version:           0.1.1
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://infinitepossibility.media
  * Author URI:        https://infinitepossibility.media


### PR DESCRIPTION
## Summary
- persist user selections using `localStorage`
- restore saved generator options when the page loads
- bump plugin version to 0.1.1

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68428477086c832ab66e9780cb05ddf5