### PR TITLE
Randomize chord modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ The plugin uses vanilla JavaScript and minimal styling. See [DESIGN.md](DESIGN.m
 
 ### Advanced Mode
 
-Check the **Advanced Mode** box to reveal additional options for chord modifiers. When enabled, generated progressions include rendered chord names.
+Check the **Advanced Mode** box to reveal additional options for chord modifiers. When enabled, a single random modifier (or none) is applied to each chord and the resulting progression includes rendered chord names.

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -78,7 +78,14 @@
             var chords = [];
             for(var i=0;i<degrees.length;i++) {
                 var deg = degrees[i]-1;
-                var chord = this.renderChord(scale[deg], qualities[deg], modifiers);
+                var mods = [];
+                if (modifiers && modifiers.length) {
+                    var idx = randomInt(-1, modifiers.length - 1);
+                    if (idx !== -1) {
+                        mods.push(modifiers[idx]);
+                    }
+                }
+                var chord = this.renderChord(scale[deg], qualities[deg], mods);
                 chords.push(chord);
             }
             return chords;

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.1.1
+Stable tag: 0.2.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.2.0
+ * Version:           0.2.1
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://infinitepossibility.media
  * Author URI:        https://infinitepossibility.media


### PR DESCRIPTION
## Summary
- randomize chord modifiers so only one (or none) gets applied per chord
- clarify Advanced Mode in README
- bump plugin version to 0.2.1

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_6842909db5f8832a9d05658372059690