### PR TITLE
Add animated slot machine UI

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -15,3 +15,30 @@
     padding-top: 0.5em;
     border-top: 1px dashed #ccc;
 }
+
+/* Animated slot styling */
+.tg-slots {
+    margin-top: 1em;
+}
+
+.slot {
+    display: inline-block;
+    overflow: hidden;
+    width: 80px;
+    height: 2em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-right: 0.25em;
+    vertical-align: bottom;
+    background: #fff;
+}
+
+.slot-reel {
+    position: relative;
+}
+
+.slot-item {
+    height: 2em;
+    line-height: 2em;
+    text-align: center;
+}

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -97,6 +97,26 @@
         }
     };
 
+    function spinSlot($slot, chord, delay) {
+        var pool = ['A','Am','B','Bm','C','Cm','D','Dm','E','Em','F','Fm','G','Gm'];
+        var $reel = $slot.find('.slot-reel');
+        $reel.empty();
+        var items = [];
+        for (var i = 0; i < 10; i++) {
+            items.push(pool[randomInt(0, pool.length - 1)]);
+        }
+        items.push(chord);
+        for (var j = 0; j < items.length; j++) {
+            $reel.append('<div class="slot-item">' + items[j] + '</div>');
+        }
+        var itemHeight = $reel.find('.slot-item').outerHeight(true);
+        var finalTop = -itemHeight * (items.length - 1);
+        $reel.css('marginTop', 0);
+        setTimeout(function(){
+            $reel.animate({ marginTop: finalTop }, 500);
+        }, delay || 0);
+    }
+
     $(function() {
         var stored = window.localStorage ? localStorage.getItem('tg-options') : null;
         if (stored) {
@@ -174,11 +194,22 @@
         result += '<p><strong>BPM:</strong> ' + tg.generateBPM(bpmMin, bpmMax) + '</p>';
         result += '<p><strong>Key:</strong> ' + keyObj.text + '</p>';
         result += '<p><strong>Progression:</strong> ' + progDegrees.join(' - ') + '</p>';
+        var chords = [];
         if (advEnabled) {
-            var chords = tg.renderProgression(progDegrees, keyObj, modifiers);
+            chords = tg.renderProgression(progDegrees, keyObj, modifiers);
             result += '<p><strong>Chords:</strong> ' + chords.join(' - ') + '</p>';
         }
 
         $('#tg-output').html(result);
+
+        var $slots = $('#tg-slots');
+        $slots.empty();
+        if (chords.length) {
+            for (var i = 0; i < chords.length; i++) {
+                var $slot = $('<div class="slot"><div class="slot-reel"></div></div>');
+                $slots.append($slot);
+                spinSlot($slot, chords[i], i * 150);
+            }
+        }
     });
 })(jQuery);

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -42,4 +42,5 @@
     <button id="tg-generate">Generate</button>
 
     <div id="tg-output"></div>
+    <div id="tg-slots" class="tg-slots"></div>
 </div>


### PR DESCRIPTION
## Summary
- append `#tg-slots` container to generator UI
- style slots and reels
- implement `spinSlot` animation helper
- update generation handler to spin slots with the new animation

## Testing
- `php -l track-generator/templates/generator-ui.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684297034f90832a9da6f616a7823cd5