### PR TITLE
Remove maj suffix from major chords

### DIFF
--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -70,7 +70,8 @@
             var name = note;
             if(quality === 'min') { name += 'm'; }
             if(quality === 'dim') { name += 'dim'; }
-            if(quality === 'maj') { name += 'maj'; }
+            // Omit explicit 'maj' for major chords
+            // This keeps plain majors like 'E' instead of 'Emaj'
             if(modifiers && modifiers.length) {
                 name += modifiers.join('');
             }


### PR DESCRIPTION
## Summary
- keep major chords simple by omitting the `maj` quality string

## Testing
- `php -l track-generator/track-generator.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6842987459d0832a8c60c8078d697630