### PR TITLE
UI overhaul with dynamic progressions

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -42,3 +42,29 @@
     line-height: 2em;
     text-align: center;
 }
+
+.tg-prog-list {
+    margin-bottom: 0.5em;
+}
+
+.tg-prog-row {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5em;
+}
+
+.tg-prog-row input[type="text"] {
+    flex: 1;
+}
+
+.tg-prog-row button {
+    margin-left: 0.5em;
+}
+
+.tg-prog-result {
+    margin-bottom: 1em;
+}
+
+.tg-slot-wrap {
+    margin-bottom: 1em;
+}

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.2.1
+Stable tag: 0.3.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -1,16 +1,17 @@
 <div class="tg-container">
-    <label for="tg-bpm-min">BPM Min</label>
-    <input id="tg-bpm-min" type="number" value="60">
+    <div id="tg-output"></div>
+    <div id="tg-slots" class="tg-slots"></div>
 
-    <label for="tg-bpm-max">BPM Max</label>
-    <input id="tg-bpm-max" type="number" value="160">
+    <fieldset>
+        <legend>Tempo</legend>
+        <label for="tg-bpm-min">BPM Min</label>
+        <input id="tg-bpm-min" type="number" value="60">
+
+        <label for="tg-bpm-max">BPM Max</label>
+        <input id="tg-bpm-max" type="number" value="160">
+    </fieldset>
 
     <label><input type="checkbox" id="tg-adv-toggle"> Advanced Mode</label>
-
-    <label for="tg-num-progs">Number of Progressions</label>
-    <input id="tg-num-progs" type="number" value="1" max="16">
-
-    <label><input type="checkbox" id="tg-suggest-song"> Suggest Song-Level Elements</label>
 
     <div id="tg-advanced" class="tg-advanced-options">
         <fieldset>
@@ -165,6 +166,21 @@
         </label>
     </fieldset>
 
+    <fieldset>
+        <legend>Progression Settings</legend>
+        <label><input type="radio" name="tg-prog-type" value="tried" checked> Tried and True</label>
+        <label><input type="radio" name="tg-prog-type" value="random"> True Random</label>
+        <label for="tg-prog-length">Progression Length (for True Random)</label>
+        <input id="tg-prog-length" type="number" value="4">
+    </fieldset>
+
+    <fieldset>
+        <legend>Progressions</legend>
+        <div id="tg-prog-list" class="tg-prog-list"></div>
+        <button type="button" id="tg-add-prog">Add Progression</button>
+    </fieldset>
+
+    <label><input type="checkbox" id="tg-suggest-song"> Suggest Song-Level Elements</label>
     <fieldset id="tg-song-elements" style="display:none;">
         <legend>Song-Level Elements</legend>
         <label>Key Change
@@ -213,17 +229,6 @@
         </label>
     </fieldset>
 
-    <fieldset>
-        <legend>Progression Type</legend>
-        <label><input type="radio" name="tg-prog-type" value="tried" checked> Tried and True</label>
-        <label><input type="radio" name="tg-prog-type" value="random"> True Random</label>
-    </fieldset>
-
-    <label for="tg-prog-length">Progression Length (for True Random)</label>
-    <input id="tg-prog-length" type="number" value="4">
-
     <button id="tg-generate">Generate</button>
-
-    <div id="tg-output"></div>
-    <div id="tg-slots" class="tg-slots"></div>
 </div>
+

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.2.1
+ * Version:           0.3.0
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://infinitepossibility.media
  * Author URI:        https://infinitepossibility.media


### PR DESCRIPTION
## Summary
- polish generator UI and move results display to the top
- allow adding/removing and naming chord progressions
- animate slot reels for each progression
- tweak styling for new progression controls
- bump version to 0.3.0

## Testing
- `node -c track-generator/js/generator.js`

------
https://chatgpt.com/codex/tasks/task_b_684303823738832abb8d53ed40916647