### PR TITLE
Improve generator UI

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -17,8 +17,10 @@
 }
 
 /* Animated slot styling */
-.tg-slots {
-    margin-top: 1em;
+
+/* Container for slot groups inside results */
+.tg-slots-group {
+    margin-top: 0.5em;
 }
 
 .slot {
@@ -65,6 +67,40 @@
     margin-bottom: 1em;
 }
 
-.tg-slot-wrap {
+/* Basic layout tweaks */
+.tg-container fieldset {
     margin-bottom: 1em;
+    padding: 0.5em;
+    border: 1px solid #ccc;
 }
+
+.tg-container legend {
+    font-weight: bold;
+}
+
+/* Modern form elements */
+.tg-container input[type="number"],
+.tg-container input[type="text"],
+.tg-container select {
+    padding: 0.25em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.tg-container button {
+    padding: 0.5em 1em;
+    border: none;
+    background: #0073aa;
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-top: 0.5em;
+}
+
+.tg-container button:hover {
+    background: #006799;
+}
+
+

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -239,14 +239,12 @@
         var allChords = [];
         for (var p = 0; p < progNames.length; p++) {
             var progDegrees = tg.generateProgression(progType, progLength);
+            var chords = tg.renderProgression(progDegrees, keyObj, advEnabled ? modWeights : null);
             result += '<section class="tg-prog-result">';
             result += '<h4>' + progNames[p] + '</h4>';
             result += '<p><strong>Degrees:</strong> ' + progDegrees.join(' - ') + '</p>';
-            var chords = [];
-            if (advEnabled) {
-                chords = tg.renderProgression(progDegrees, keyObj, modWeights);
-                result += '<p><em>Chords:</em> ' + chords.join(' - ') + '</p>';
-            }
+            result += '<p><em>Chords:</em> ' + chords.join(' - ') + '</p>';
+            result += '<div class="tg-slots-group"></div>';
             result += '</section>';
             allChords.push(chords);
         }
@@ -260,21 +258,14 @@
 
         $('#tg-output').html(result);
 
-        var $slots = $('#tg-slots');
-        $slots.empty();
-        for (var p = 0; p < allChords.length; p++) {
+        $('#tg-output .tg-prog-result').each(function(p){
             var chords = allChords[p];
-            if (!chords.length) { continue; }
-            var $wrap = $('<div class="tg-slot-wrap"></div>');
-            $wrap.append('<h4>' + progNames[p] + '</h4>');
-            var $group = $('<div class="tg-slots-group"></div>');
+            var $group = $(this).find('.tg-slots-group');
             for (var i = 0; i < chords.length; i++) {
                 var $slot = $('<div class="slot"><div class="slot-reel"></div></div>');
                 $group.append($slot);
-                spinSlot($slot, chords[i], i * 150);
+                spinSlot($slot, chords[i], p * 500 + i * 150);
             }
-            $wrap.append($group);
-            $slots.append($wrap);
-        }
+        });
     });
 })(jQuery);

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -1,6 +1,6 @@
 <div class="tg-container">
+    <button id="tg-generate">Generate</button>
     <div id="tg-output"></div>
-    <div id="tg-slots" class="tg-slots"></div>
 
     <fieldset>
         <legend>Tempo</legend>
@@ -229,6 +229,5 @@
         </label>
     </fieldset>
 
-    <button id="tg-generate">Generate</button>
 </div>
 


### PR DESCRIPTION
## Summary
- move Generate button above the form so results are visible when clicked
- show chord names and slot animation even when Advanced Mode is disabled
- combine progression results with slot animations
- stagger slot groups and tweak styling
- modernize styling of all form fields and buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68430a30e530832ab1d6ba08fb28af74