### PR TITLE
Add unmodified chord variation and adjust weight options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ The plugin uses vanilla JavaScript and minimal styling. See [DESIGN.md](DESIGN.m
 
 ### Advanced Mode
 
-Check the **Advanced Mode** box to reveal additional options for chord modifiers. When enabled, a single random modifier (or none) is applied to each chord and the resulting progression includes rendered chord names.
+Check the **Advanced Mode** box to reveal weighted chord variations. Each variation (7th, sus2, etc.) can be given a probability and an **Unmodified** weight controls how often no change is applied. If Unmodified is set to **Always**, other variation weights are ignored.

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -135,8 +135,14 @@
             var chords = [];
             var modOptions = [];
             if (modWeights) {
-                for (var m in modWeights) {
-                    modOptions.push({ value: m, weight: modWeights[m] });
+                var unmod = modWeights['unmodified'] || 0;
+                var unmodAlways = unmod === weightLevels[6];
+                modOptions.push({ value: null, weight: unmod });
+                if (!unmodAlways) {
+                    for (var m in modWeights) {
+                        if (m === 'unmodified') { continue; }
+                        modOptions.push({ value: m, weight: modWeights[m] });
+                    }
                 }
             }
             for(var i=0;i<degrees.length;i++) {

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.3.0
+Stable tag: 0.4.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -15,9 +15,9 @@
 
     <div id="tg-advanced" class="tg-advanced-options">
         <fieldset>
-            <legend>Chord Modifiers</legend>
-            <label>7th
-                <select name="tg-mod-7" data-mod="7">
+            <legend>Chord Variation</legend>
+            <label>Unmodified
+                <select name="tg-mod-unmodified" data-mod="unmodified">
                     <option value="0">None</option>
                     <option value="1">Very Rare</option>
                     <option value="2">Rare</option>
@@ -26,6 +26,16 @@
                     <option value="5">Abundant</option>
                     <option value="6">Always</option>
                 </select>
+            </label>
+            <label>7th
+                <select name="tg-mod-7" data-mod="7">
+                    <option value="0">None</option>
+                    <option value="1">Very Rare</option>
+                    <option value="2">Rare</option>
+                    <option value="3">Uncommon</option>
+                    <option value="4">Common</option>
+                    <option value="5">Abundant</option>
+                                    </select>
             </label>
             <label>sus2
                 <select name="tg-mod-sus2" data-mod="sus2">
@@ -35,8 +45,7 @@
                     <option value="3">Uncommon</option>
                     <option value="4">Common</option>
                     <option value="5">Abundant</option>
-                    <option value="6">Always</option>
-                </select>
+                                    </select>
             </label>
             <label>sus4
                 <select name="tg-mod-sus4" data-mod="sus4">
@@ -46,8 +55,7 @@
                     <option value="3">Uncommon</option>
                     <option value="4">Common</option>
                     <option value="5">Abundant</option>
-                    <option value="6">Always</option>
-                </select>
+                                    </select>
             </label>
             <label>diminished
                 <select name="tg-mod-dim" data-mod="dim">
@@ -57,8 +65,7 @@
                     <option value="3">Uncommon</option>
                     <option value="4">Common</option>
                     <option value="5">Abundant</option>
-                    <option value="6">Always</option>
-                </select>
+                                    </select>
             </label>
             <label>augmented
                 <select name="tg-mod-aug" data-mod="aug">
@@ -68,8 +75,7 @@
                     <option value="3">Uncommon</option>
                     <option value="4">Common</option>
                     <option value="5">Abundant</option>
-                    <option value="6">Always</option>
-                </select>
+                                    </select>
             </label>
             <label>power
                 <select name="tg-mod-power" data-mod="power">
@@ -79,8 +85,7 @@
                     <option value="3">Uncommon</option>
                     <option value="4">Common</option>
                     <option value="5">Abundant</option>
-                    <option value="6">Always</option>
-                </select>
+                                    </select>
             </label>
         </fieldset>
     </div>
@@ -95,8 +100,7 @@
                 <option value="3" selected>Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Natural Minor
             <select name="tg-mode-natural" data-mode="Natural Minor">
@@ -106,8 +110,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4" selected>Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Dorian
             <select name="tg-mode-dorian" data-mode="Dorian">
@@ -117,8 +120,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Phrygian
             <select name="tg-mode-phrygian" data-mode="Phrygian">
@@ -128,8 +130,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Lydian
             <select name="tg-mode-lydian" data-mode="Lydian">
@@ -139,8 +140,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Mixolydian
             <select name="tg-mode-mixolydian" data-mode="Mixolydian">
@@ -150,8 +150,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Locrian
             <select name="tg-mode-locrian" data-mode="Locrian">
@@ -161,8 +160,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
     </fieldset>
 
@@ -191,8 +189,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Tempo Shift
             <select name="tg-song-tempo" data-song="Tempo Shift">
@@ -202,8 +199,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Dynamics Change
             <select name="tg-song-dynamics" data-song="Dynamics Change">
@@ -213,8 +209,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
         <label>Rhythm Variation
             <select name="tg-song-rhythm" data-song="Rhythm Variation">
@@ -224,8 +219,7 @@
                 <option value="3">Uncommon</option>
                 <option value="4">Common</option>
                 <option value="5">Abundant</option>
-                <option value="6">Always</option>
-            </select>
+                            </select>
         </label>
     </fieldset>
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.3.0
+ * Version:           0.4.0
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://infinitepossibility.media
  * Author URI:        https://infinitepossibility.media


### PR DESCRIPTION
## Summary
- add Unmodified chord variation option
- remove `Always` from weight dropdowns and keep only for Unmodified
- handle unmodified logic in JS
- document updated behaviour and bump plugin version to 0.4.0

## Testing
- `php -l track-generator.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68430ba1c228832aa5c44eaef382deea