### PR TITLE
Add sticky summary and copy-to-clipboard

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -33,6 +33,7 @@
     margin-right: 0.25em;
     vertical-align: bottom;
     background: #fff;
+    cursor: pointer;
 }
 
 .slot-reel {
@@ -67,15 +68,30 @@
     margin-bottom: 1em;
 }
 
+.tg-degrees {
+    color: #666;
+    font-style: italic;
+}
+
+.tg-chords {
+    color: #000;
+    font-weight: bold;
+}
+
 /* Basic layout tweaks */
 .tg-container fieldset {
     margin-bottom: 1em;
-    padding: 0.5em;
+    padding: 1rem;
     border: 1px solid #ccc;
+    background: #f8f8f8;
+    border-radius: 8px;
 }
 
 .tg-container legend {
     font-weight: bold;
+    border-left: 4px solid #007acc;
+    padding-left: 0.5rem;
+    margin-bottom: 0.25rem;
 }
 
 /* Modern form elements */
@@ -101,6 +117,28 @@
 
 .tg-container button:hover {
     background: #006799;
+}
+
+#tg-output-summary {
+    position: sticky;
+    top: 0;
+    background: #fff;
+    padding: 0.25em 0.5em;
+    border-bottom: 1px solid #ccc;
+    z-index: 10;
+}
+
+.tg-toast {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 0.5em 1em;
+    border-radius: 4px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
 }
 
 

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -239,17 +239,15 @@
 
         var bpm = tg.generateBPM(bpmMin, bpmMax);
         var keyObj = tg.generateKey(modeWeights);
-        var result = '';
-        result += '<p><strong>BPM:</strong> ' + bpm + '</p>';
-        result += '<p><strong>Key:</strong> ' + keyObj.text + '</p>';
+        var result = '<div id="tg-output-summary"><strong>' + keyObj.text + '</strong> - ' + bpm + ' BPM</div>';
         var allChords = [];
         for (var p = 0; p < progNames.length; p++) {
             var progDegrees = tg.generateProgression(progType, progLength);
             var chords = tg.renderProgression(progDegrees, keyObj, advEnabled ? modWeights : null);
             result += '<section class="tg-prog-result">';
             result += '<h4>' + progNames[p] + '</h4>';
-            result += '<p><strong>Degrees:</strong> ' + progDegrees.join(' - ') + '</p>';
-            result += '<p><em>Chords:</em> ' + chords.join(' - ') + '</p>';
+            result += '<p class="tg-degrees"><strong>Degrees:</strong> ' + progDegrees.join(' - ') + '</p>';
+            result += '<p class="tg-chords"><em>Chords:</em> ' + chords.join(' - ') + '</p>';
             result += '<div class="tg-slots-group"></div>';
             result += '</section>';
             allChords.push(chords);
@@ -268,10 +266,31 @@
             var chords = allChords[p];
             var $group = $(this).find('.tg-slots-group');
             for (var i = 0; i < chords.length; i++) {
-                var $slot = $('<div class="slot"><div class="slot-reel"></div></div>');
+                var $slot = $('<div class="slot" title="Click to copy" data-chord="' + chords[i] + '"><div class="slot-reel"></div></div>');
                 $group.append($slot);
                 spinSlot($slot, chords[i], p * 500 + i * 150);
             }
         });
     });
+
+    $(document).on('click', '.slot', function(){
+        var chord = $(this).data('chord');
+        if (chord && navigator.clipboard) {
+            navigator.clipboard.writeText(chord).then(function(){
+                showToast('Copied!');
+            });
+        }
+    });
+
+    function showToast(msg) {
+        var $toast = $('#tg-toast');
+        if (!$toast.length) {
+            $toast = $('<div id="tg-toast" class="tg-toast"></div>').appendTo('body');
+        }
+        $toast.text(msg).css('opacity', 1);
+        clearTimeout($toast.data('timer'));
+        $toast.data('timer', setTimeout(function(){
+            $toast.css('opacity', 0);
+        }, 1000));
+    }
 })(jQuery);


### PR DESCRIPTION
## Summary
- highlight generator sections for readability
- differentiate progression degrees vs chords
- create a sticky output summary
- allow copying chord slots to clipboard with a toast

## Testing
- `php -l track-generator/track-generator.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68430e524714832ab8873d64caea056c