### PR TITLE
Add collapsible settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A WordPress plugin that generates random ideas for new music tracks. It provides
 - Key and mode selector supporting all seven modes (Ionian, Dorian, Phrygian, Lydian, Mixolydian, Aeolian, Locrian)
 - Two chord progression modes: "Tried and True" or a fully random sequence
 - Optional Advanced Mode with chord modifiers and rendered chord names
+- Collapsible settings panel that hides after generating results
 
 ## Installation
 

--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -9,6 +9,14 @@
     margin: 0.5em 0 0.2em;
 }
 
+#tg-settings.collapsed {
+    display: none;
+}
+
+#tg-settings-toggle {
+    margin-left: 0.5em;
+}
+
 .tg-advanced-options {
     display: none;
     margin-top: 0.5em;

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -191,6 +191,11 @@
             $('#tg-advanced').toggle(this.checked);
         }).trigger('change');
 
+        $('#tg-settings-toggle').on('click', function(){
+            $('#tg-settings').toggleClass('collapsed');
+            $(this).text($('#tg-settings').hasClass('collapsed') ? 'Show Settings' : 'Hide Settings');
+        });
+
         $('#tg-suggest-song').on('change', function(){
             $('#tg-song-elements').toggle(this.checked);
         }).trigger('change');
@@ -212,6 +217,8 @@
     });
 
     $(document).on('click', '#tg-generate', function() {
+        $('#tg-settings').addClass('collapsed');
+        $('#tg-settings-toggle').text('Show Settings');
         var bpmMin = parseInt($('#tg-bpm-min').val(), 10);
         var bpmMax = parseInt($('#tg-bpm-max').val(), 10);
         var modeWeights = {};

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -1,6 +1,9 @@
 <div class="tg-container">
     <button id="tg-generate">Generate</button>
+    <button type="button" id="tg-settings-toggle">Hide Settings</button>
     <div id="tg-output"></div>
+
+    <div id="tg-settings">
 
     <fieldset>
         <legend>Tempo</legend>
@@ -222,6 +225,8 @@
                             </select>
         </label>
     </fieldset>
+
+    </div> <!-- end tg-settings -->
 
 </div>
 


### PR DESCRIPTION
## Summary
- add a button to show/hide plugin settings
- collapse the settings area after generation
- style collapsed section
- document new feature in README

## Testing
- `php -l track-generator/track-generator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684312a3b868832ab86caa7a964fceb4