### PR TITLE
Add chord chart popups

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -149,4 +149,37 @@
     pointer-events: none;
 }
 
+.tg-chord-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 999;
+}
+
+.tg-chord-popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #fff;
+    padding: 1em;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    z-index: 1000;
+    max-width: 90%;
+}
+
+.tg-chord-close {
+    position: absolute;
+    top: 0.25em;
+    right: 0.25em;
+    background: transparent;
+    border: none;
+    font-size: 1.25em;
+    cursor: pointer;
+}
+
 

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -254,7 +254,10 @@
             result += '<section class="tg-prog-result">';
             result += '<h4>' + progNames[p] + '</h4>';
             result += '<p class="tg-degrees"><strong>Degrees:</strong> ' + progDegrees.join(' - ') + '</p>';
-            result += '<p class="tg-chords"><em>Chords:</em> ' + chords.join(' - ') + '</p>';
+            var chordLinks = chords.map(function(c){
+                return '<a href="#" class="tg-chord-link" data-chord="' + c + '">' + c + '</a>';
+            });
+            result += '<p class="tg-chords"><em>Chords:</em> ' + chordLinks.join(' - ') + '</p>';
             result += '<div class="tg-slots-group"></div>';
             result += '</section>';
             allChords.push(chords);
@@ -289,6 +292,14 @@
         }
     });
 
+    $(document).on('click', '.tg-chord-link', function(e){
+        e.preventDefault();
+        var chord = $(this).data('chord');
+        if (chord) {
+            showChordPopup(chord);
+        }
+    });
+
     function showToast(msg) {
         var $toast = $('#tg-toast');
         if (!$toast.length) {
@@ -299,5 +310,23 @@
         $toast.data('timer', setTimeout(function(){
             $toast.css('opacity', 0);
         }, 1000));
+    }
+
+    function showChordPopup(chord) {
+        var $overlay = $('<div class="tg-chord-overlay"></div>');
+        var $popup = $('<div class="tg-chord-popup"></div>');
+        var $close = $('<button type="button" class="tg-chord-close">&times;</button>');
+        var $content = $('<div data-chord="' + chord + '" data-instrument="guitar" data-output="image"></div>');
+        $popup.append($close).append($content);
+        $('body').append($overlay).append($popup);
+        $close.on('click', remove);
+        $overlay.on('click', remove);
+        if (window.renderScalesChords) {
+            window.renderScalesChords();
+        }
+        function remove() {
+            $overlay.remove();
+            $popup.remove();
+        }
     }
 })(jQuery);

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -24,6 +24,13 @@ function tg_enqueue_assets() {
         null,
         true
     );
+    wp_enqueue_script(
+        'scales-chords-api',
+        'https://www.scales-chords.com/api/scales-chords-api.js',
+        array(),
+        null,
+        true
+    );
 }
 add_action('wp_enqueue_scripts', 'tg_enqueue_assets');
 


### PR DESCRIPTION
## Summary
- load scales-chords.com API
- show chord names as clickable links
- display chord chart popup when clicking a chord
- style popup overlay

## Testing
- `php -l track-generator/track-generator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684315f8dd64832aa09a98fd4e97b760