### PR TITLE
Fix chord popup for scales-chords API

### DIFF
--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -316,7 +316,7 @@
         var $overlay = $('<div class="tg-chord-overlay"></div>');
         var $popup = $('<div class="tg-chord-popup"></div>');
         var $close = $('<button type="button" class="tg-chord-close">&times;</button>');
-        var $content = $('<div data-chord="' + chord + '" data-instrument="guitar" data-output="image"></div>');
+        var $content = $('<div class="scales_chords_api" data-chord="' + chord + '" data-instrument="guitar" data-output="image"></div>');
         $popup.append($close).append($content);
         $('body').append($overlay).append($popup);
         $close.on('click', remove);


### PR DESCRIPTION
## Summary
- ensure dynamically generated chord divs include the `scales_chords_api` class so the external API processes them

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6843187e2f04832aafd751e9dfe164a4