### PR TITLE
Implement selectable key feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A WordPress plugin that generates random ideas for new music tracks. It provides
 - Two chord progression modes: "Tried and True" or a fully random sequence
 - Optional Advanced Mode with chord modifiers and rendered chord names
 - Collapsible settings panel that hides after generating results
+- Ability to restrict generation to selected keys
 
 ## Installation
 

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -36,9 +36,10 @@
         generateBPM: function(min, max) {
             return randomInt(min, max);
         },
-        generateKey: function(modeWeights) {
+        generateKey: function(modeWeights, allowedKeys) {
             var keys = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'];
-            var key = keys[randomInt(0, keys.length - 1)];
+            var pool = (allowedKeys && allowedKeys.length) ? allowedKeys : keys;
+            var key = pool[randomInt(0, pool.length - 1)];
             var modeOptions = [];
             for (var m in modeWeights) {
                 modeOptions.push({ value: m, weight: modeWeights[m] });
@@ -242,6 +243,11 @@ function addProgRow(name) {
                 if (s.flavorWeights[k] !== undefined) { $(this).val(s.flavorWeights[k]); }
             });
         }
+        if (s.keys) {
+            $('.tg-key-option').each(function(){
+                $(this).prop('checked', s.keys.indexOf($(this).val()) !== -1);
+            });
+        }
     }
 
     $(function() {
@@ -306,6 +312,10 @@ function addProgRow(name) {
         $('select[data-song]').each(function(){
             songWeights[$(this).data('song')] = parseInt($(this).val(), 10);
         });
+        var allowedKeys = [];
+        $('.tg-key-option:checked').each(function(){
+            allowedKeys.push($(this).val());
+        });
 
         var settings = {
             bpmMin: bpmMin,
@@ -315,14 +325,15 @@ function addProgRow(name) {
             progLength: progLength,
             advEnabled: advEnabled,
             modWeights: modWeights,
-            flavorWeights: flavorWeights
+            flavorWeights: flavorWeights,
+            keys: allowedKeys
         };
         try {
             localStorage.setItem('tgSettings', JSON.stringify(settings));
         } catch(e) {}
 
         var bpm = tg.generateBPM(bpmMin, bpmMax);
-        var keyObj = tg.generateKey(modeWeights);
+        var keyObj = tg.generateKey(modeWeights, allowedKeys);
         var result = '<div id="tg-output-summary"><strong>' + keyObj.text + '</strong> - ' + bpm + ' BPM</div>';
         var allChords = [];
         for (var p = 0; p < progNames.length; p++) {

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.5.0
+Stable tag: 0.6.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -14,6 +14,22 @@
         <input id="tg-bpm-max" type="number" value="160">
     </fieldset>
 
+    <fieldset>
+        <legend>Allowed Keys</legend>
+        <label><input type="checkbox" class="tg-key-option" value="A" checked> A</label>
+        <label><input type="checkbox" class="tg-key-option" value="A#" checked> A#</label>
+        <label><input type="checkbox" class="tg-key-option" value="B" checked> B</label>
+        <label><input type="checkbox" class="tg-key-option" value="C" checked> C</label>
+        <label><input type="checkbox" class="tg-key-option" value="C#" checked> C#</label>
+        <label><input type="checkbox" class="tg-key-option" value="D" checked> D</label>
+        <label><input type="checkbox" class="tg-key-option" value="D#" checked> D#</label>
+        <label><input type="checkbox" class="tg-key-option" value="E" checked> E</label>
+        <label><input type="checkbox" class="tg-key-option" value="F" checked> F</label>
+        <label><input type="checkbox" class="tg-key-option" value="F#" checked> F#</label>
+        <label><input type="checkbox" class="tg-key-option" value="G" checked> G</label>
+        <label><input type="checkbox" class="tg-key-option" value="G#" checked> G#</label>
+    </fieldset>
+
     <label><input type="checkbox" id="tg-adv-toggle"> Advanced Mode</label>
 
     <div id="tg-advanced" class="tg-advanced-options">

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.5.0
+ * Version:           0.6.0
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://infinitepossibility.media
  * Author URI:        https://infinitepossibility.media


### PR DESCRIPTION
## Summary
- add ability to restrict key generation
- bump version to 0.6.0
- document new feature

## Testing
- `php -l track-generator/track-generator.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684340a21284832a80088faec9afa647