### PR TITLE
Release 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ The plugin uses jQuery, Bootstrap, and minimal styling. See [DESIGN.md](DESIGN.m
 ### Advanced Mode
 
 Check the **Advanced Mode** box to reveal weighted chord variations. Each variation (7th, sus2, etc.) can be given a probability and an **Unmodified** weight controls how often no change is applied. If Unmodified is set to **Always**, other variation weights are ignored.
+
+## Community and Support
+
+Track Generator is brought to you by [TheUbie](https://www.youtube.com/@theubie).
+If you encounter issues or have feature requests, please open an issue on
+[GitHub](https://github.com/theubie/trackgenerator/issues).
+Generously given to you for free! If you want to be generous back,
+[click here](https://streamelements.com/theubie-fc49c/tip) to leave a tip.

--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -177,4 +177,10 @@
     color: #555;
 }
 
+.tg-about {
+    margin-top: 1em;
+    font-size: 0.9em;
+    color: #555;
+}
+
 

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,8 +3,14 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.6.0
+Stable tag: 0.7.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
 A simple tool for generating random track ideas.
+
+Track Generator is brought to you by [TheUbie](https://www.youtube.com/@theubie).
+Report issues or request new features on
+<https://github.com/theubie/trackgenerator/issues>.
+Generously given to you for free! If you want to be generous back,
+visit <https://streamelements.com/theubie-fc49c/tip> to leave a tip.

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -269,5 +269,17 @@
 
     </div> <!-- end tg-settings -->
 
+    <div class="tg-about">
+        <h3>About This App</h3>
+        <p>
+            Track Generator is brought to you by
+            <a href="https://www.youtube.com/@theubie">TheUbie</a>.
+            Found a bug or have a feature request?
+            <a href="https://github.com/theubie/trackgenerator/issues">Let me know on GitHub</a>.
+            Enjoying it? <a href="https://streamelements.com/theubie-fc49c/tip">leave a tip</a>
+            if you like.
+        </p>
+    </div>
+
 </div>
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.6.0
+ * Version:           0.7.0
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://infinitepossibility.media
  * Author URI:        https://infinitepossibility.media


### PR DESCRIPTION
## Summary
- bump plugin version to **0.7.0**
- add community links in README
- include issue tracker, YouTube channel, and tip jar in plugin readme
- add a short "About This App" section inside the generator UI

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68437699e4f4832a8a1601805b214862