### PR TITLE
Add GitHub update checker

### DIFF
--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -12,6 +12,12 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
+if (!defined('TRACK_GENERATOR_VERSION')) {
+    define('TRACK_GENERATOR_VERSION', '0.7.0');
+}
+
+require_once plugin_dir_path(__FILE__) . 'update-checker.php';
+
 function tg_enqueue_assets() {
     wp_enqueue_style(
         'track-generator-style',

--- a/track-generator/update-checker.php
+++ b/track-generator/update-checker.php
@@ -1,0 +1,53 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+/**
+ * Check GitHub releases for plugin updates.
+ *
+ * Hooks into pre_set_site_transient_update_plugins and injects update
+ * information when a newer version is available.
+ */
+function tg_check_for_updates($transient) {
+    if (empty($transient->checked)) {
+        return $transient;
+    }
+
+    $response = wp_remote_get(
+        'https://api.github.com/repos/theubie/trackgenerator/releases/latest',
+        [
+            'headers' => [
+                'Accept' => 'application/vnd.github+json',
+                'User-Agent' => 'WordPress'
+            ]
+        ]
+    );
+
+    if (is_wp_error($response)) {
+        return $transient;
+    }
+
+    $release = json_decode(wp_remote_retrieve_body($response));
+    if (!$release || empty($release->tag_name) || empty($release->zipball_url)) {
+        return $transient;
+    }
+
+    $latest_version = ltrim($release->tag_name, 'v');
+    if (version_compare($latest_version, TRACK_GENERATOR_VERSION, '>')) {
+        $plugin_slug = plugin_basename(__DIR__ . '/track-generator.php');
+
+        $plugin = (object) [
+            'slug' => 'track-generator',
+            'plugin' => $plugin_slug,
+            'new_version' => $latest_version,
+            'url' => $release->html_url,
+            'package' => $release->zipball_url,
+        ];
+
+        $transient->response[$plugin_slug] = $plugin;
+    }
+
+    return $transient;
+}
+add_filter('pre_set_site_transient_update_plugins', 'tg_check_for_updates');


### PR DESCRIPTION
## Summary
- add a simple GitHub update checker for the plugin
- define a plugin version constant
- load update checker from main plugin file

## Testing
- `php -l track-generator/update-checker.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68439373403c832a8f90a43a42c84a07