### PR TITLE
Bump plugin version to 0.8.0

### DIFF
--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.7.0
+Stable tag: 0.8.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.7.0
+ * Version:           0.8.0
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://infinitepossibility.media
  * Author URI:        https://infinitepossibility.media
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('TRACK_GENERATOR_VERSION')) {
-    define('TRACK_GENERATOR_VERSION', '0.7.0');
+    define('TRACK_GENERATOR_VERSION', '0.8.0');
 }
 
 require_once plugin_dir_path(__FILE__) . 'update-checker.php';


### PR DESCRIPTION
## Summary
- bump plugin header and constant to version 0.8.0
- update stable tag in readme.txt

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68439832f914832ab6a892d1f53323c2