### PR TITLE
Fix update checker hook

### DIFF
--- a/track-generator/update-checker.php
+++ b/track-generator/update-checker.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 /**
  * Check GitHub releases for plugin updates.
  *
- * Hooks into pre_set_site_transient_update_plugins and injects update
+ * Hooks into site_transient_update_plugins and injects update
  * information when a newer version is available.
  */
 function tg_check_for_updates($transient) {
@@ -50,4 +50,4 @@ function tg_check_for_updates($transient) {
 
     return $transient;
 }
-add_filter('pre_set_site_transient_update_plugins', 'tg_check_for_updates');
+add_filter('site_transient_update_plugins', 'tg_check_for_updates');


### PR DESCRIPTION
## Summary
- register update checker on `site_transient_update_plugins`
- update comment to match the new hook

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843a0540164832a869caaf7e22cb531