### PR TITLE
Fix GitHub updater request headers

### DIFF
--- a/track-generator/update-checker.php
+++ b/track-generator/update-checker.php
@@ -19,8 +19,11 @@ function tg_check_for_updates($transient) {
         [
             'headers' => [
                 'Accept' => 'application/vnd.github+json',
-                'User-Agent' => 'WordPress'
-            ]
+                'User-Agent' => 'TrackGenerator/' . TRACK_GENERATOR_VERSION .
+                    ' (+https://github.com/theubie/trackgenerator)'
+            ],
+            'timeout' => 10,
+            'redirection' => 3,
         ]
     );
 


### PR DESCRIPTION
## Summary
- strengthen GitHub API request headers
- add timeout and redirection options

## Testing
- `php -l track-generator/update-checker.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6843a416112c832aabc224093c3e623b