### PR TITLE
Release 0.8.1

### DIFF
--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.8.0
+Stable tag: 0.8.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,9 +2,9 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.8.0
+ * Version:           0.8.1
  * Author:            Randell Miller of Infinite Possibility Media
- * Plugin URI:        https://infinitepossibility.media
+ * Plugin URI:        https://github.com/theubie/trackgenerator
  * Author URI:        https://infinitepossibility.media
  */
 
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('TRACK_GENERATOR_VERSION')) {
-    define('TRACK_GENERATOR_VERSION', '0.8.0');
+    define('TRACK_GENERATOR_VERSION', '0.8.1');
 }
 
 require_once plugin_dir_path(__FILE__) . 'update-checker.php';

--- a/track-generator/update-checker.php
+++ b/track-generator/update-checker.php
@@ -4,31 +4,14 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Write debug information to Query Monitor if available.
- * Falls back to error_log when WP_DEBUG is enabled.
- *
- * @param mixed $message Message to log.
- * @return void
- */
-function tg_log_debug($message) {
-    do_action('qm/debug', $message);
-
-    if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log(print_r($message, true));
-    }
-}
-
-/**
  * Check GitHub releases for plugin updates.
  *
  * Hooks into site_transient_update_plugins and injects update
  * information when a newer version is available.
  */
 function tg_check_for_updates($transient) {
-    tg_log_debug('Checking GitHub for Track Generator updates. Current version: ' . TRACK_GENERATOR_VERSION);
 
     if (empty($transient->checked)) {
-        tg_log_debug('No plugins checked yet, exiting update check.');
         return $transient;
     }
 
@@ -44,24 +27,18 @@ function tg_check_for_updates($transient) {
             'redirection' => 3,
         ]
     );
-    tg_log_debug('GitHub update check response code: ' . wp_remote_retrieve_response_code($response));
 
     if (is_wp_error($response)) {
-        tg_log_debug('Update check HTTP error: ' . $response->get_error_message());
         return $transient;
     }
 
     $release = json_decode(wp_remote_retrieve_body($response));
-    tg_log_debug(['release_data' => $release]);
     if (!$release || empty($release->tag_name) || empty($release->zipball_url)) {
-        tg_log_debug('Incomplete release information received from GitHub.');
         return $transient;
     }
 
     $latest_version = ltrim($release->tag_name, 'v');
-    tg_log_debug('Latest GitHub version: ' . $latest_version);
     if (version_compare($latest_version, TRACK_GENERATOR_VERSION, '>')) {
-        tg_log_debug('Update available. Preparing plugin info.');
         $plugin_slug = plugin_basename(__DIR__ . '/track-generator.php');
 
         $download_url = $release->zipball_url;
@@ -83,10 +60,7 @@ function tg_check_for_updates($transient) {
             'package' => $download_url,
         ];
 
-        tg_log_debug(['update_plugin_data' => $plugin]);
         $transient->response[$plugin_slug] = $plugin;
-    } else {
-        tg_log_debug('No update found.');
     }
 
     return $transient;


### PR DESCRIPTION
## Summary
- bump Track Generator to 0.8.1
- point plugin URI at GitHub repo
- clean out debug logging

## Testing
- `php -l track-generator/templates/generator-ui.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843b269bb70832aac9473ae87c33c94