### PR TITLE
Add plugin info popup override

### DIFF
--- a/track-generator/plugin-info.php
+++ b/track-generator/plugin-info.php
@@ -1,0 +1,55 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+function tg_fetch_latest_release() {
+    $response = wp_remote_get(
+        'https://api.github.com/repos/theubie/trackgenerator/releases/latest',
+        [
+            'headers' => [
+                'Accept' => 'application/vnd.github+json',
+                'User-Agent' => 'TrackGenerator/' . TRACK_GENERATOR_VERSION . ' (+https://github.com/theubie/trackgenerator)'
+            ],
+            'timeout' => 10,
+            'redirection' => 3,
+        ]
+    );
+
+    if (is_wp_error($response)) {
+        return null;
+    }
+
+    $release = json_decode(wp_remote_retrieve_body($response));
+    if (!$release || empty($release->body) || empty($release->tag_name)) {
+        return null;
+    }
+
+    return (object) [
+        'version' => ltrim($release->tag_name, 'v'),
+        'changelog' => $release->body,
+    ];
+}
+
+function tg_override_plugin_info($res, $action, $args) {
+    if ($action === 'plugin_information' && isset($args->slug) && $args->slug === 'track-generator') {
+        $release = tg_fetch_latest_release();
+        $version = $release ? $release->version : TRACK_GENERATOR_VERSION;
+        $changelog = $release ? $release->changelog : '';
+
+        return (object) [
+            'name' => 'Track Generator',
+            'slug' => 'track-generator',
+            'version' => $version,
+            'author' => '<a href="https://infinitepossibility.media">TheUbie</a>',
+            'homepage' => 'https://github.com/theubie/trackgenerator',
+            'short_description' => 'Randomized track and progression generator for songwriters and streamers.',
+            'sections' => [
+                'description' => 'Create musical inspiration in seconds with customizable key, tempo, and chord options.',
+                'changelog' => $changelog,
+            ],
+        ];
+    }
+    return $res;
+}
+add_filter('plugins_api', 'tg_override_plugin_info', 20, 3);

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.8.1
+Stable tag: 0.8.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.8.1
+ * Version:           0.8.2
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://github.com/theubie/trackgenerator
  * Author URI:        https://infinitepossibility.media
@@ -18,10 +18,11 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('TRACK_GENERATOR_VERSION')) {
-    define('TRACK_GENERATOR_VERSION', '0.8.1');
+    define('TRACK_GENERATOR_VERSION', '0.8.2');
 }
 
 require_once plugin_dir_path(__FILE__) . 'update-checker.php';
+require_once plugin_dir_path(__FILE__) . 'plugin-info.php';
 
 function tg_enqueue_assets() {
     wp_enqueue_style(


### PR DESCRIPTION
## Summary
- override WP plugin info popup to avoid "Plugin not found" error
- pull changelog from GitHub releases
- bump version to 0.8.2

## Testing
- `php -l track-generator/plugin-info.php` *(fails: command not found)*
- `php -l track-generator/track-generator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843b7089910832ab62a535f0f218dbe