### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A WordPress plugin that generates random ideas for new music tracks. It provides
 - Optional Advanced Mode with chord modifiers and rendered chord names
 - Collapsible settings panel that hides after generating results
 - Ability to restrict generation to selected keys
+- Optional dark mode toggle for low-light environments
 
 ## Installation
 

--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -9,6 +9,11 @@
     margin: 0.5em 0 0.2em;
 }
 
+.tg-dark-toggle {
+    display: inline-block;
+    margin-left: 0.5em;
+}
+
 #tg-settings.collapsed {
     display: none;
 }
@@ -181,6 +186,51 @@
     margin-top: 1em;
     font-size: 0.9em;
     color: #555;
+}
+
+/* Dark mode styles */
+.tg-container.tg-dark-mode {
+    background: #222;
+    color: #eee;
+    border-color: #555;
+}
+.tg-container.tg-dark-mode fieldset {
+    background: #333;
+    border-color: #555;
+}
+.tg-container.tg-dark-mode input[type="number"],
+.tg-container.tg-dark-mode input[type="text"],
+.tg-container.tg-dark-mode select {
+    background: #444;
+    color: #eee;
+    border-color: #666;
+}
+.tg-container.tg-dark-mode button {
+    background: #006799;
+}
+.tg-container.tg-dark-mode button:hover {
+    background: #005f8f;
+}
+.tg-container.tg-dark-mode #tg-output-summary {
+    background: #333;
+    border-color: #555;
+}
+.tg-container.tg-dark-mode .tg-degrees {
+    color: #bbb;
+}
+.tg-container.tg-dark-mode .tg-chords {
+    color: #fff;
+}
+.tg-container.tg-dark-mode .tg-roman {
+    color: #ccc;
+}
+.tg-container.tg-dark-mode .tg-chord-popup {
+    background: #333;
+    border-color: #555;
+    color: #eee;
+}
+.tg-container.tg-dark-mode .tg-about {
+    color: #ccc;
 }
 
 

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -264,6 +264,21 @@ function addProgRow(name) {
                 $(this).prop('checked', s.keys.indexOf($(this).val()) !== -1);
             });
         }
+        if (s.darkMode) {
+            $('#tg-dark-toggle').prop('checked', true);
+            $('.tg-container').addClass('tg-dark-mode');
+        }
+    }
+
+    function saveDarkSetting(val) {
+        var existing = {};
+        try {
+            existing = JSON.parse(localStorage.getItem('tgSettings')) || {};
+        } catch(e) {}
+        existing.darkMode = val;
+        try {
+            localStorage.setItem('tgSettings', JSON.stringify(existing));
+        } catch(e) {}
     }
 
     $(function() {
@@ -291,6 +306,11 @@ function addProgRow(name) {
                 addProgRow('Progression 1');
             }
         });
+
+        $('#tg-dark-toggle').on('change', function(){
+            $('.tg-container').toggleClass('tg-dark-mode', this.checked);
+            saveDarkSetting(this.checked);
+        }).trigger('change');
 
         if ($('#tg-prog-list .tg-prog-row').length === 0) {
             addProgRow('Progression 1');
@@ -342,7 +362,8 @@ function addProgRow(name) {
             advEnabled: advEnabled,
             modWeights: modWeights,
             flavorWeights: flavorWeights,
-            keys: allowedKeys
+            keys: allowedKeys,
+            darkMode: $('#tg-dark-toggle').is(':checked')
         };
         try {
             localStorage.setItem('tgSettings', JSON.stringify(settings));

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.9.0
+Stable tag: 0.10.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -1,6 +1,7 @@
 <div class="tg-container">
     <button id="tg-generate">Generate</button>
     <button type="button" id="tg-settings-toggle">Hide Settings</button>
+    <label class="tg-dark-toggle"><input type="checkbox" id="tg-dark-toggle"> Dark Mode</label>
     <div id="tg-output"></div>
 
     <div id="tg-settings">

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.9.0
+ * Version:           0.10.0
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://github.com/theubie/trackgenerator
  * Author URI:        https://infinitepossibility.media
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('TRACK_GENERATOR_VERSION')) {
-    define('TRACK_GENERATOR_VERSION', '0.9.0');
+    define('TRACK_GENERATOR_VERSION', '0.10.0');
 }
 
 require_once plugin_dir_path(__FILE__) . 'update-checker.php';


### PR DESCRIPTION
## Summary
- enable dark mode with new checkbox on the generator UI
- persist dark mode setting in `localStorage`
- add dark mode styles
- bump version to 0.10.0
- document dark mode in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6843be8b0aec832a9f050202f8a27981