### PR TITLE
Fix slot color in dark mode

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -233,4 +233,9 @@
     color: #ccc;
 }
 
+.tg-container.tg-dark-mode .slot {
+    background: #444;
+    border-color: #666;
+}
+
 


### PR DESCRIPTION
## Summary
- update CSS so `.slot` has dark mode styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6843c292c184832a8c016c7159189f12