### PR TITLE
Add progression reroll feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A WordPress plugin that generates random ideas for new music tracks. It provides
 - Optional Advanced Mode with chord modifiers and rendered chord names
 - Collapsible settings panel that hides after generating results
 - Ability to restrict generation to selected keys
+- Reroll individual progressions without losing others
 - Optional dark mode toggle for low-light environments
 
 ## Installation

--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -80,6 +80,10 @@
     margin-bottom: 1em;
 }
 
+.tg-reroll-prog {
+    margin-bottom: 0.5em;
+}
+
 .tg-degrees {
     color: inherit;
     font-style: italic;

--- a/track-generator/readme.txt
+++ b/track-generator/readme.txt
@@ -3,7 +3,7 @@ Contributors: randellmiller
 Tags: music, bpm, chord progression, key
 Requires at least: 5.0
 Tested up to: 6.2
-Stable tag: 0.10.1
+Stable tag: 0.11.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/track-generator/track-generator.php
+++ b/track-generator/track-generator.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Track Generator
  * Description:       Generates random BPM, key, mode, and chord progressions.
- * Version:           0.10.1
+ * Version:           0.11.0
  * Author:            Randell Miller of Infinite Possibility Media
  * Plugin URI:        https://github.com/theubie/trackgenerator
  * Author URI:        https://infinitepossibility.media
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('TRACK_GENERATOR_VERSION')) {
-    define('TRACK_GENERATOR_VERSION', '0.10.1');
+    define('TRACK_GENERATOR_VERSION', '0.11.0');
 }
 
 require_once plugin_dir_path(__FILE__) . 'update-checker.php';


### PR DESCRIPTION
## Summary
- add ability to reroll individual progressions
- style reroll button
- bump plugin version to 0.11.0
- document new feature

## Testing
- `node -c track-generator/js/generator.js`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68447185e488832aba7d61d5ee32a3cb