### PR TITLE
Style reroll button and hide slot animation

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -81,7 +81,15 @@
 }
 
 .tg-reroll-prog {
-    margin-bottom: 0.5em;
+    font-size: 0.8em;
+    padding: 0.15em 0.35em;
+    margin-right: 0.25em;
+    line-height: 1;
+    vertical-align: middle;
+    margin-top: 0;
+    background: transparent;
+    border: none;
+    color: inherit;
 }
 
 .tg-degrees {
@@ -212,6 +220,9 @@
 }
 .tg-container.tg-dark-mode button:hover {
     background: #005f8f;
+}
+.tg-container.tg-dark-mode .tg-reroll-prog {
+    background: transparent;
 }
 .tg-container.tg-dark-mode #tg-output-summary {
     background: #333;

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -222,6 +222,9 @@
         setTimeout(function(){
             $reel.animate({ marginTop: finalTop }, 500);
         }, delay || 0);
+        setTimeout(function(){
+            $slot.fadeOut(400, function(){ $(this).remove(); });
+        }, (delay || 0) + 2000);
     }
 
 function addProgRow(name) {
@@ -392,8 +395,10 @@ function addProgRow(name) {
             var progDegrees = tg.generateProgression(progType, progLength);
             var chords = tg.renderProgression(progDegrees, keyObj, advEnabled ? modWeights : null, advEnabled ? flavorWeights : null);
             result += '<section class="tg-prog-result" data-idx="' + p + '">';
-            result += '<h4>' + progNames[p] + '</h4>';
-            result += '<button type="button" class="tg-reroll-prog" data-idx="' + p + '">Reroll</button>';
+            result += '<h4>' +
+                '<button type="button" class="tg-reroll-prog" data-idx="' + p + '" aria-label="Reroll">&#x21bb;</button>' +
+                progNames[p] +
+                '</h4>';
             result += '<p class="tg-degrees"><strong>Degrees:</strong> ' + progDegrees.join(' - ') + '</p>';
             var chordLinks = chords.map(function(c){
                 return '<span class="tg-chord-wrap"><a href="#" class="tg-chord-link" data-chord="' + c.chord + '">' + c.chord + '</a> <span class="tg-roman">(' + c.roman + ')</span></span>';


### PR DESCRIPTION
## Summary
- display the reroll button to the left of the progression name using an icon
- fade out each slot animation after a short delay
- style the new icon button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684475e16750832aaf60ae395a57841b