### PR TITLE
Add collapsible settings and persist progression names

### DIFF
--- a/track-generator/css/style.css
+++ b/track-generator/css/style.css
@@ -81,7 +81,7 @@
 }
 
 .tg-reroll-prog {
-    font-size: 0.8em;
+    font-size: 0.4em;
     padding: 0.15em 0.35em;
     margin-right: 0.25em;
     line-height: 1;
@@ -116,6 +116,15 @@
     border-left: 4px solid currentColor;
     padding-left: 0.5rem;
     margin-bottom: 0.25rem;
+}
+
+/* Collapsible settings sections */
+.tg-collapsible legend {
+    cursor: pointer;
+}
+
+.tg-collapsible.collapsed > *:not(legend) {
+    display: none;
 }
 
 /* Modern form elements */

--- a/track-generator/js/generator.js
+++ b/track-generator/js/generator.js
@@ -234,6 +234,24 @@ function addProgRow(name) {
             '</div>');
         if (name) { $row.find('input').val(name); }
         $('#tg-prog-list').append($row);
+        saveProgNames();
+}
+
+function saveProgNames() {
+        var names = [];
+        $('#tg-prog-list .tg-prog-row').each(function(idx){
+            var n = $(this).find('.tg-prog-name').val().trim();
+            if (!n) { n = 'Progression ' + (idx + 1); }
+            names.push(n);
+        });
+        var existing = {};
+        try {
+            existing = JSON.parse(localStorage.getItem('tgSettings')) || {};
+        } catch(e) {}
+        existing.progNames = names;
+        try {
+            localStorage.setItem('tgSettings', JSON.stringify(existing));
+        } catch(e) {}
 }
 
     function loadSettings() {
@@ -275,6 +293,12 @@ function addProgRow(name) {
             $('#tg-dark-toggle').prop('checked', true);
             $('.tg-container').addClass('tg-dark-mode');
         }
+        if (s.progNames && s.progNames.length) {
+            $('#tg-prog-list').empty();
+            for (var i = 0; i < s.progNames.length; i++) {
+                addProgRow(s.progNames[i]);
+            }
+        }
     }
 
     function saveDarkSetting(val) {
@@ -312,6 +336,13 @@ function addProgRow(name) {
             if ($('#tg-prog-list .tg-prog-row').length === 0) {
                 addProgRow('Progression 1');
             }
+            saveProgNames();
+        });
+
+        $(document).on('input', '.tg-prog-name', saveProgNames);
+
+        $(document).on('click', '.tg-collapsible > legend', function(){
+            $(this).parent().toggleClass('collapsed');
         });
 
         $('#tg-dark-toggle').on('change', function(){
@@ -350,6 +381,7 @@ function addProgRow(name) {
             if (!name) { name = 'Progression ' + (idx + 1); }
             progNames.push(name);
         });
+        saveProgNames();
         var suggestSong = $('#tg-suggest-song').is(':checked');
         var songWeights = {};
         $('select[data-song]').each(function(){
@@ -370,7 +402,8 @@ function addProgRow(name) {
             modWeights: modWeights,
             flavorWeights: flavorWeights,
             keys: allowedKeys,
-            darkMode: $('#tg-dark-toggle').is(':checked')
+            darkMode: $('#tg-dark-toggle').is(':checked'),
+            progNames: progNames
         };
         try {
             localStorage.setItem('tgSettings', JSON.stringify(settings));

--- a/track-generator/templates/generator-ui.php
+++ b/track-generator/templates/generator-ui.php
@@ -6,7 +6,7 @@
 
     <div id="tg-settings">
 
-    <fieldset>
+    <fieldset class="tg-collapsible">
         <legend>Tempo</legend>
         <label for="tg-bpm-min">BPM Min</label>
         <input id="tg-bpm-min" type="number" value="60">
@@ -15,7 +15,7 @@
         <input id="tg-bpm-max" type="number" value="160">
     </fieldset>
 
-    <fieldset>
+    <fieldset class="tg-collapsible">
         <legend>Allowed Keys</legend>
         <label><input type="checkbox" class="tg-key-option" value="A" checked> A</label>
         <label><input type="checkbox" class="tg-key-option" value="A#" checked> A#</label>
@@ -34,7 +34,7 @@
     <label><input type="checkbox" id="tg-adv-toggle"> Advanced Mode</label>
 
     <div id="tg-advanced" class="tg-advanced-options">
-        <fieldset>
+        <fieldset class="tg-collapsible">
             <legend>Chord Variation</legend>
             <label>Unmodified
                 <select name="tg-mod-unmodified" data-mod="unmodified">
@@ -108,7 +108,7 @@
                                     </select>
             </label>
         </fieldset>
-        <fieldset>
+        <fieldset class="tg-collapsible">
             <legend>Functional Flavor</legend>
             <label>Borrowed
                 <select name="tg-flavor-borrowed" data-flavor="borrowed">
@@ -135,7 +135,7 @@
         </fieldset>
     </div>
 
-    <fieldset>
+    <fieldset class="tg-collapsible">
         <legend>Modes</legend>
         <label>Major
             <select name="tg-mode-major" data-mode="Major">
@@ -209,7 +209,7 @@
         </label>
     </fieldset>
 
-    <fieldset>
+    <fieldset class="tg-collapsible">
         <legend>Progression Settings</legend>
         <label><input type="radio" name="tg-prog-type" value="tried" checked> Tried and True</label>
         <label><input type="radio" name="tg-prog-type" value="random"> True Random</label>
@@ -217,14 +217,14 @@
         <input id="tg-prog-length" type="number" value="4">
     </fieldset>
 
-    <fieldset>
+    <fieldset class="tg-collapsible">
         <legend>Progressions</legend>
         <div id="tg-prog-list" class="tg-prog-list"></div>
         <button type="button" id="tg-add-prog">Add Progression</button>
     </fieldset>
 
     <label><input type="checkbox" id="tg-suggest-song"> Suggest Song-Level Elements</label>
-    <fieldset id="tg-song-elements" style="display:none;">
+    <fieldset id="tg-song-elements" class="tg-collapsible" style="display:none;">
         <legend>Song-Level Elements</legend>
         <label>Key Change
             <select name="tg-song-keychange" data-song="Key Change">


### PR DESCRIPTION
## Summary
- style reroll button a bit smaller
- allow settings fieldsets to collapse by clicking legends
- remember progression names in localStorage

## Testing
- `php -l track-generator/track-generator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844780a4be0832aacfe73aea427890d